### PR TITLE
SC was missing in BRDocuments::IE.available_states

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ BRDocuments::IE.available_states
 => [
   "AC", "AL", "AM", "AP", "BA", "CE", "DF", "ES", "GO",
   "MA", "MG", "MS", "MT", "PA", "PB", "PE", "PI", "PR",
-  "RJ", "RN", "RO", "RR", "RS", "SE", "SP", "TO"
+  "RJ", "RN", "RO", "RR", "RS", "SC", "SE", "SP", "TO"
 ]
 
 ## Ex

--- a/lib/br_documents/documents/ie.rb
+++ b/lib/br_documents/documents/ie.rb
@@ -29,6 +29,7 @@ module BRDocuments
       'RO',
       'RR',
       'RS',
+      'SC',
       'SE',
       'SP',
       'TO'

--- a/spec/documents/ie_spec.rb
+++ b/spec/documents/ie_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe BRDocuments::IE do
+  describe '.availabe_states' do
+
+    it 'has 27 elements' do
+      expect(BRDocuments::IE::available_states.count).to eq(27)
+    end
+
+    it 'includes all brazilian states' do
+      expect(BRDocuments::IE::available_states)
+        .to  include("AC")
+        .and include("AL")
+        .and include("AM")
+        .and include("AP")
+        .and include("BA")
+        .and include("CE")
+        .and include("DF")
+        .and include("ES")
+        .and include("GO")
+        .and include("MA")
+        .and include("MG")
+        .and include("MS")
+        .and include("MT")
+        .and include("PA")
+        .and include("PB")
+        .and include("PE")
+        .and include("PI")
+        .and include("PR")
+        .and include("RJ")
+        .and include("RN")
+        .and include("RO")
+        .and include("RR")
+        .and include("RS")
+        .and include("SC")
+        .and include("SE")
+        .and include("SP")
+        .and include("TO")
+    end
+  end
+end


### PR DESCRIPTION
Adds Santa Catarina ('SC') to BRDocuments::IE.available_states.