### PR TITLE
Broaden fixed digits for RJ

### DIFF
--- a/lib/br_documents/documents/ie/rj.rb
+++ b/lib/br_documents/documents/ie/rj.rb
@@ -8,7 +8,7 @@ module BRDocuments
 
     set_pretty_format_mask %(%s.%s.%s)
 
-    set_fixed_digits (11..99).to_a
+    set_fixed_digits (10..99).to_a
 
     def self.valid_fixed_digits?(number)
       number = new(number).normalize

--- a/spec/documents/ie/rj_spec.rb
+++ b/spec/documents/ie/rj_spec.rb
@@ -37,6 +37,7 @@ describe BRDocuments::IE::RJ do
       '78.166.886', # MUNDO POPULAR BAZAR LTDA
       '92.013.405', # CREDEAL MANUFATURA DE PAPEIS LTDA
       '11.075.169', # ATACADAO S/A
+      '10.012.040', # FUNDACAO COPPETEC
     ]
   end
 


### PR DESCRIPTION
Tive um problema com a IE 10.012.040 - CNPJ 72.060.999/0001-75 -, que é válida e criada em 2015, sendo apontada como inválida